### PR TITLE
Removing IO.inspect

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -17,7 +17,6 @@ defmodule Plugsnag do
             stacktrace = System.stacktrace
 
             exception
-            |> IO.inspect
             |> Bugsnag.report
 
             reraise exception, stacktrace


### PR DESCRIPTION
Logger will catch it since we re-raise. No need to inspect as well.
