### PR TITLE
Unwrap plug errors with handle_errors

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -3,8 +3,8 @@ defmodule Plugsnag do
     quote location: :keep do
       use Plug.ErrorHandler
 
-      defp handle_errors(_conn, %{reason: exception, stack: stack}) do
-        Bugsnag.report(exception, stack)
+      defp handle_errors(_conn, %{reason: exception, stack: _stack}) do
+        Bugsnag.report(exception, release_stage: Atom.to_string(Mix.env))
       end
     end
   end

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -3,10 +3,9 @@ defmodule Plugsnag do
     quote location: :keep do
       use Plug.ErrorHandler
 
-      defp handle_errors(_conn, %{reason: exception, stack: _stack}) do
+      defp handle_errors(_conn, %{reason: exception, stack: stack}) do
         Bugsnag.report(exception, release_stage: Atom.to_string(Mix.env))
       end
     end
   end
-
 end

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -1,27 +1,12 @@
 defmodule Plugsnag do
   defmacro __using__(_env) do
     quote location: :keep do
-      @before_compile Plugsnag
-    end
-  end
+      use Plug.ErrorHandler
 
-  defmacro __before_compile__(_env) do
-    quote location: :keep do
-      defoverridable [call: 2]
-
-      def call(conn, opts) do
-        try do
-          super(conn, opts)
-        rescue
-          exception ->
-            stacktrace = System.stacktrace
-
-            exception
-            |> Bugsnag.report(release_stage: Atom.to_string(Mix.env))
-
-            reraise exception, stacktrace
-        end
+      defp handle_errors(_conn, %{reason: exception, stack: stack}) do
+        Bugsnag.report(exception, stack)
       end
     end
   end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Plugsnag.Mixfile do
 
   defp deps do
     [{:bugsnag, "~> 1.2"},
-     {:plug, "~> 1.1.0", only: [:test]}
+     {:plug, "~> 1.0"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,8 @@ defmodule Plugsnag.Mixfile do
   end
 
   defp deps do
-    [{:bugsnag, "~> 1.2"}]
+    [{:bugsnag, "~> 1.2"},
+     {:plug, "~> 1.1.0", only: [:test]}
+    ]
   end
 end


### PR DESCRIPTION
This is a signficant reworking, but I discovered it as I tried to fix #3.

I think it's going to make our lives easier by shunting the error handling off
to plug, and we can do nice things like pass through things to Bugsnag as
options.

This gives us unwrapped exceptions for free. The only downside that I
can see at this point is that we've lost the stack trace in the console
output. I'm going to try and sort that out before I land the PR.
