### PR TITLE
Add conn metadata to the report

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -1,4 +1,6 @@
 defmodule Plugsnag do
+
+
   defmacro __using__(_env) do
     quote location: :keep do
       use Plug.ErrorHandler
@@ -19,8 +21,26 @@ defmodule Plugsnag do
         Application.get_env(:plugsnag, :reporter, Bugsnag)
       end
 
-      defp handle_errors(_conn, %{reason: exception}) do
-        reporter.report(exception)
+      defp handle_errors(conn, %{reason: exception}) do
+        reporter.report(exception, metadata: extract_metadata(conn))
+      end
+
+      defp extract_metadata(conn) do
+        %{
+          conn: %{
+            request_path: conn.request_path,
+            method: conn.method,
+            port: conn.port,
+            scheme: conn.scheme,
+            query_string: conn.query_string
+          }
+        }
+      end
+
+      defp format_ip(ip) do
+        ip
+        |> Tuple.to_list
+        |> Enum.join(".")
       end
     end
   end

--- a/test/plugsnag_test.exs
+++ b/test/plugsnag_test.exs
@@ -31,9 +31,28 @@ defmodule PlugsnagTest do
     conn = conn(:get, "/")
 
     assert_raise Exception, "oops", fn ->
-      conn == TestPlug.call(conn, [])
+      TestPlug.call(conn, [])
     end
 
     assert_received {:report, {%Exception{}, _}}
   end
+
+  test "includes conn info in the report" do
+    conn = conn(:get, "/?hello=computer")
+
+    catch_error TestPlug.call(conn, [])
+
+    assert_received {:report, {%Exception{}, options}}
+
+    assert %{conn: %{
+                request_path: "/",
+                method: "GET",
+                port: 80,
+                scheme: :http,
+                query_string: "hello=computer"
+             }
+    } = Keyword.get(options, :metadata)
+  end
+
+
 end


### PR DESCRIPTION
This will add metadata from the `Plug.Conn` to a `conn` metadata tab in Bugsnag.
