### PR TITLE
Allow customizing error reports before sending to Bugsnag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ defmodule YourApp.Router do
 end
 ```
 
+### Filtering Parameters
+
+By default, the `BasicErrorReportBuilder` will filter out password parameters from error reports sent to Bugsnag. You can customize this list inside your configuration:
+
+```elixir
+config :plugsnag, :filter_parameters, ~w(password password_confirmation super_sekrit)
+```
+
 ## Customizing error reporting
 
 You can also customize how an error is sent to bugsnag-elixir by passing your

--- a/README.md
+++ b/README.md
@@ -28,3 +28,39 @@ defmodule YourApp.Router do
   # ...
 end
 ```
+
+## Customizing error reporting
+
+You can also customize how an error is sent to bugsnag-elixir by passing your
+own custom ErrorReportBuilder with the `:error_report_builder` option.
+
+```elixir
+defmodule YourApp.Router do
+  use Phoenix.Router
+  use Plugsnag, error_report_builder: YourApp.ErrorReportBuilder
+
+  # ...
+end
+```
+
+```elixir
+defmodule YourApp.ErrorReportBuilder do
+  @behaviour Plugsnag.ErrorReportBuilder
+
+  def build_error_report(error_report, conn) do
+    error_report
+    |> Plugsnag.BasicErrorReportBuilder.build_error_report(conn)
+    |> put_user_info(conn)
+  end
+
+  defp put_user_info(error_report, conn) do
+    current_user = conn.assigns[:current_user]
+
+    user_info =  %{
+      id: current_user.id
+    }
+
+    %{error_report | user: user_info}
+  end
+end
+```

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -1,7 +1,8 @@
 defmodule Plugsnag do
-  defmacro __using__(_env) do
+  defmacro __using__(options \\ []) do
     quote location: :keep do
       use Plug.ErrorHandler
+      import Plugsnag
 
       if :code.is_loaded(Phoenix) do
         defp handle_errors(_conn, %{reason: %Phoenix.Router.NoRouteError{}}) do
@@ -15,13 +16,27 @@ defmodule Plugsnag do
         end
       end
 
-      defp reporter do
-        Application.get_env(:plugsnag, :reporter, Bugsnag)
-      end
+      defp handle_errors(conn, %{reason: exception}) do
+        error_report_builder = unquote(
+          Keyword.get(
+            options,
+            :error_report_builder,
+            Plugsnag.BasicErrorReportBuilder
+          )
+        )
 
-      defp handle_errors(_conn, %{reason: exception}) do
-        reporter.report(exception)
+        options =
+          %Plugsnag.ErrorReport{}
+          |> error_report_builder.build_error_report(conn)
+          |> Map.delete(:__struct__)
+          |> Keyword.new
+
+        apply(reporter, :report, [exception | [options]])
       end
     end
+  end
+
+  def reporter do
+    Application.get_env(:plugsnag, :reporter, Bugsnag)
   end
 end

--- a/lib/plugsnag/basic_error_report_builder.ex
+++ b/lib/plugsnag/basic_error_report_builder.ex
@@ -2,7 +2,7 @@ defmodule Plugsnag.BasicErrorReportBuilder do
   @moduledoc """
   Error report builder that adds basic context to the ErrorReport.
   """
-
+  @default_filter_parameters ~w(password)
   @behaviour Plugsnag.ErrorReportBuilder
 
   def build_error_report(error_report, conn) do
@@ -21,7 +21,7 @@ defmodule Plugsnag.BasicErrorReportBuilder do
         port: conn.port,
         scheme: conn.scheme,
         query_string: conn.query_string,
-        params: conn.params,
+        params: filter_params(conn.params),
         headers: collect_req_headers(conn)
       }
     }
@@ -32,4 +32,19 @@ defmodule Plugsnag.BasicErrorReportBuilder do
       Map.put(acc, header, Plug.Conn.get_req_header(conn, header) |> List.first)
     end)
   end
+
+  defp filter_params(params), do: do_filter_params(params, Application.get_env(:plugsnag, :filter_parameters, @default_filter_parameters))
+
+  def do_filter_params(%{__struct__: mod} = struct, _params_to_filter) when is_atom(mod), do: struct
+  def do_filter_params(%{} = map, params_to_filter) do
+    Enum.into map, %{}, fn {k, v} ->
+      if is_binary(k) && String.contains?(k, params_to_filter) do
+        {k, "[FILTERED]"}
+      else
+        {k, do_filter_params(v, params_to_filter)}
+      end
+    end
+  end
+  def do_filter_params([_|_] = list, params_to_filter), do: Enum.map(list, &do_filter_params(&1, params_to_filter))
+  def do_filter_params(other, _params_to_filter), do: other
 end

--- a/lib/plugsnag/basic_error_report_builder.ex
+++ b/lib/plugsnag/basic_error_report_builder.ex
@@ -2,7 +2,7 @@ defmodule Plugsnag.BasicErrorReportBuilder do
   @moduledoc """
   Error report builder that adds basic context to the ErrorReport.
   """
-  @default_filter_parameters ~w(password)
+  @default_filter_parameters params: ~w(password)
   @behaviour Plugsnag.ErrorReportBuilder
 
   def build_error_report(error_report, conn) do
@@ -21,30 +21,42 @@ defmodule Plugsnag.BasicErrorReportBuilder do
         port: conn.port,
         scheme: conn.scheme,
         query_string: conn.query_string,
-        params: filter_params(conn.params),
+        params: filter(:params, conn.params),
         headers: collect_req_headers(conn)
       }
     }
   end
 
   defp collect_req_headers(conn) do
-    Enum.reduce(conn.req_headers, %{}, fn({header, _}, acc) ->
+    headers = Enum.reduce(conn.req_headers, %{}, fn({header, _}, acc) ->
       Map.put(acc, header, Plug.Conn.get_req_header(conn, header) |> List.first)
     end)
+    filter(:headers, headers)
   end
 
-  defp filter_params(params), do: do_filter_params(params, Application.get_env(:plugsnag, :filter_parameters, @default_filter_parameters))
+  defp filters_for(:headers) do
+    do_filters_for(:headers) |> Enum.map(&String.downcase/1)
+  end
 
-  def do_filter_params(%{__struct__: mod} = struct, _params_to_filter) when is_atom(mod), do: struct
-  def do_filter_params(%{} = map, params_to_filter) do
+  defp filters_for(field), do: do_filters_for(field)
+
+  defp do_filters_for(field) do
+    Application.get_env(:plugsnag, :filter, @default_filter_parameters)
+    |> Keyword.get(field, [])
+  end
+
+  defp filter(field, data), do: do_filter(data, filters_for(field))
+
+  def do_filter(%{__struct__: mod} = struct, _params_to_filter) when is_atom(mod), do: struct
+  def do_filter(%{} = map, params_to_filter) do
     Enum.into map, %{}, fn {k, v} ->
       if is_binary(k) && String.contains?(k, params_to_filter) do
         {k, "[FILTERED]"}
       else
-        {k, do_filter_params(v, params_to_filter)}
+        {k, do_filter(v, params_to_filter)}
       end
     end
   end
-  def do_filter_params([_|_] = list, params_to_filter), do: Enum.map(list, &do_filter_params(&1, params_to_filter))
-  def do_filter_params(other, _params_to_filter), do: other
+  def do_filter([_|_] = list, params_to_filter), do: Enum.map(list, &do_filter(&1, params_to_filter))
+  def do_filter(other, _params_to_filter), do: other
 end

--- a/lib/plugsnag/basic_error_report_builder.ex
+++ b/lib/plugsnag/basic_error_report_builder.ex
@@ -1,0 +1,35 @@
+defmodule Plugsnag.BasicErrorReportBuilder do
+  @moduledoc """
+  Error report builder that adds basic context to the ErrorReport.
+  """
+
+  @behaviour Plugsnag.ErrorReportBuilder
+
+  def build_error_report(error_report, conn) do
+    %{error_report | metadata: build_metadata(conn)}
+  end
+
+  defp build_metadata(conn) do
+    conn =
+      conn
+      |> Plug.Conn.fetch_query_params
+
+    %{
+      request: %{
+        request_path: conn.request_path,
+        method: conn.method,
+        port: conn.port,
+        scheme: conn.scheme,
+        query_string: conn.query_string,
+        params: conn.params,
+        headers: collect_req_headers(conn)
+      }
+    }
+  end
+
+  defp collect_req_headers(conn) do
+    Enum.reduce(conn.req_headers, %{}, fn({header, _}, acc) ->
+      Map.put(acc, header, Plug.Conn.get_req_header(conn, header) |> List.first)
+    end)
+  end
+end

--- a/lib/plugsnag/basic_error_report_builder.ex
+++ b/lib/plugsnag/basic_error_report_builder.ex
@@ -47,8 +47,8 @@ defmodule Plugsnag.BasicErrorReportBuilder do
 
   defp filter(field, data), do: do_filter(data, filters_for(field))
 
-  def do_filter(%{__struct__: mod} = struct, _params_to_filter) when is_atom(mod), do: struct
-  def do_filter(%{} = map, params_to_filter) do
+  defp do_filter(%{__struct__: mod} = struct, _params_to_filter) when is_atom(mod), do: struct
+  defp do_filter(%{} = map, params_to_filter) do
     Enum.into map, %{}, fn {k, v} ->
       if is_binary(k) && String.contains?(k, params_to_filter) do
         {k, "[FILTERED]"}
@@ -57,6 +57,6 @@ defmodule Plugsnag.BasicErrorReportBuilder do
       end
     end
   end
-  def do_filter([_|_] = list, params_to_filter), do: Enum.map(list, &do_filter(&1, params_to_filter))
-  def do_filter(other, _params_to_filter), do: other
+  defp do_filter([_|_] = list, params_to_filter), do: Enum.map(list, &do_filter(&1, params_to_filter))
+  defp do_filter(other, _params_to_filter), do: other
 end

--- a/lib/plugsnag/basic_error_report_builder.ex
+++ b/lib/plugsnag/basic_error_report_builder.ex
@@ -22,7 +22,8 @@ defmodule Plugsnag.BasicErrorReportBuilder do
         scheme: conn.scheme,
         query_string: conn.query_string,
         params: filter(:params, conn.params),
-        headers: collect_req_headers(conn)
+        headers: collect_req_headers(conn),
+        client_ip: format_ip(conn.remote_ip)
       }
     }
   end
@@ -59,4 +60,10 @@ defmodule Plugsnag.BasicErrorReportBuilder do
   end
   defp do_filter([_|_] = list, params_to_filter), do: Enum.map(list, &do_filter(&1, params_to_filter))
   defp do_filter(other, _params_to_filter), do: other
+
+  defp format_ip(ip) do
+    ip
+    |> Tuple.to_list
+    |> Enum.join(".")
+  end
 end

--- a/lib/plugsnag/error_report.ex
+++ b/lib/plugsnag/error_report.ex
@@ -1,0 +1,14 @@
+defmodule Plugsnag.ErrorReport do
+  @moduledoc """
+  A Plugsnag error report
+  """
+
+  @type t ::  %__MODULE__{
+    severity: String.t | nil,
+    context: String.t | nil,
+    metadata: map() | nil,
+    user: map() | nil
+  }
+
+  defstruct [:severity, :context, :metadata, :user]
+end

--- a/lib/plugsnag/error_report_builder.ex
+++ b/lib/plugsnag/error_report_builder.ex
@@ -1,0 +1,4 @@
+defmodule Plugsnag.ErrorReportBuilder do
+
+  @callback build_error_report(Plugsnag.ErrorReport.t, Plug.Conn.t) :: Plugsnag.ErrorReport.t
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,9 @@ defmodule Plugsnag.Mixfile do
      description: """
        Bugsnag reporter for Elixir's Plug
      """,
-     deps: deps]
+     deps: deps,
+     dialyzer: [plt_add_deps: :project]
+   ]
   end
 
   def package do
@@ -24,7 +26,8 @@ defmodule Plugsnag.Mixfile do
 
   defp deps do
     [{:bugsnag, "~> 1.3"},
-     {:plug, "~> 1.0"}
+     {:plug, "~> 1.0"},
+     {:dialyxir, "~> 0.3.5", only: [:dev]}
     ]
   end
 end

--- a/test/plugsnag/basic_error_report_builder_test.exs
+++ b/test/plugsnag/basic_error_report_builder_test.exs
@@ -30,7 +30,8 @@ defmodule Plugsnag.BasicErrorReportBuilderTest do
           headers: %{
             "accept" => "application/json",
             "x-user-id" => "abc123"
-          }
+          },
+          client_ip: "127.0.0.1"
         }
       }
     }

--- a/test/plugsnag/basic_error_report_builder_test.exs
+++ b/test/plugsnag/basic_error_report_builder_test.exs
@@ -1,0 +1,38 @@
+defmodule Plugsnag.BasicErrorReportBuilderTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  alias Plugsnag.BasicErrorReportBuilder
+  alias Plugsnag.ErrorReport
+
+  test "build_error_report/3 adds the appropriate fields to the error report" do
+    conn = conn(:get, "/?hello=computer")
+
+    conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("x-user-id", "abc123")
+
+    error_report = BasicErrorReportBuilder.build_error_report(
+      %ErrorReport{}, conn
+    )
+
+
+    assert error_report == %ErrorReport{
+      metadata: %{
+        request: %{
+          request_path: "/",
+          method: "GET",
+          port: 80,
+          scheme: :http,
+          query_string: "hello=computer",
+          params: %{"hello" => "computer"},
+          headers: %{
+            "accept" => "application/json",
+            "x-user-id" => "abc123"
+          }
+        }
+      }
+    }
+  end
+end

--- a/test/plugsnag/basic_error_report_builder_test.exs
+++ b/test/plugsnag/basic_error_report_builder_test.exs
@@ -35,4 +35,21 @@ defmodule Plugsnag.BasicErrorReportBuilderTest do
       }
     }
   end
+
+  test "filters the params defined in config" do
+    Application.put_env(:plugsnag, :filter_parameters, ~w(password receipt))
+
+    conn = conn(:post, "/", %{"password" => "secret", "user" => "foo"})
+
+    error_report = BasicErrorReportBuilder.build_error_report(%ErrorReport{}, conn)
+
+    assert %ErrorReport{
+      metadata: %{
+        request: %{
+          params: %{"password" => "[FILTERED]", "user" => "foo"}
+        }
+      }
+    } = error_report
+  end
+
 end

--- a/test/plugsnag_test.exs
+++ b/test/plugsnag_test.exs
@@ -84,4 +84,5 @@ defmodule PlugsnagTest do
      id: "abc123"
     }
   end
+
 end

--- a/test/plugsnag_test.exs
+++ b/test/plugsnag_test.exs
@@ -1,20 +1,26 @@
-
 defmodule PlugsnagTest do
   use ExUnit.Case
   use Plug.Test
 
-  defmodule Exception do
+  defmodule TestException do
     defexception plug_status: 403, message: "oops"
+  end
+
+  defmodule ErrorRaisingPlug do
+    defmacro __using__(_env) do
+      quote do
+        def call(conn, _opts) do
+          raise Plug.Conn.WrapperError, conn: conn,
+          kind: :error, stack: System.stacktrace,
+          reason: TestException.exception([])
+        end
+      end
+    end
   end
 
   defmodule TestPlug do
     use Plugsnag
-
-    def call(conn, _opts) do
-      raise Plug.Conn.WrapperError, conn: conn,
-      kind: :error, stack: System.stacktrace,
-      reason: Exception.exception([])
-    end
+    use ErrorRaisingPlug
   end
 
   defmodule FakePlugsnag do
@@ -30,10 +36,52 @@ defmodule PlugsnagTest do
   test "Raising an error on failure" do
     conn = conn(:get, "/")
 
-    assert_raise Exception, "oops", fn ->
-      conn == TestPlug.call(conn, [])
+    assert_raise TestException, "oops", fn ->
+      TestPlug.call(conn, [])
     end
 
-    assert_received {:report, {%Exception{}, _}}
+    assert_received {:report, {%TestException{}, _}}
+  end
+
+  test "includes connection metadata in the report" do
+    conn = conn(:get, "/?hello=computer")
+
+    catch_error TestPlug.call(conn, [])
+    assert_received {:report, {%TestException{}, options}}
+    metadata = Keyword.get(options, :metadata)
+
+    assert get_in(metadata, [:request,:query_string]) == "hello=computer"
+  end
+
+  test "allows modifying bugsnag report options before it's sent" do
+    defmodule TestErrorReportBuilder do
+      @behaviour Plugsnag.ErrorReportBuilder
+
+      def build_error_report(error_report, conn) do
+        user_info =  %{
+          id: conn |> get_req_header("x-user-id") |> List.first
+        }
+
+        %{error_report | user: user_info}
+      end
+    end
+
+    defmodule TestPlugsnagCallbackPlug do
+      use Plugsnag, error_report_builder: TestErrorReportBuilder
+      use ErrorRaisingPlug
+    end
+
+    conn = conn(:get, "/")
+
+    conn =
+      conn
+      |> put_req_header("x-user-id", "abc123")
+
+    catch_error TestPlugsnagCallbackPlug.call(conn, [])
+    assert_received {:report, {%TestException{}, options}}
+
+    assert Keyword.get(options, :user) == %{
+     id: "abc123"
+    }
   end
 end


### PR DESCRIPTION
This was heavily inspired by @mootpointer's work on #12 to add context when reporting to bugsnag, but also allows the developer to customize the context that's sent.

I added an example to the readme as well as a couple examples in the tests. Please let me know what you think. I'd be happy to make any adjustments to ensure this is a good, extensible api for developers.
