### PR TITLE
Don't report Phoenix.ActionClauseError to Bugsnag

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -16,6 +16,11 @@ defmodule Plugsnag do
         end
       end
 
+      # Phoenix turns these into 400s, so don't want to Bugsnag them, as this
+      # type of match error isn't really an unhandled exception, but a feature of
+      # Phoenix routing/controllers.
+      defp handle_errors(conn, %{reason: %Phoenix.ActionClauseError{}}), do: nil
+
       defp handle_errors(conn, %{reason: exception}) do
         error_report_builder = unquote(
           Keyword.get(

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -16,10 +16,12 @@ defmodule Plugsnag do
         end
       end
 
-      # Phoenix turns these into 400s, so don't want to Bugsnag them, as this
-      # type of match error isn't really an unhandled exception, but a feature of
-      # Phoenix routing/controllers.
-      defp handle_errors(conn, %{reason: %Phoenix.ActionClauseError{}}), do: nil
+      if :code.is_loaded(Phoenix) do
+        # Phoenix turns these into 400s, so don't want to Bugsnag them, as this
+        # type of match error isn't really an unhandled exception, but a feature of
+        # Phoenix routing/controllers.
+        defp handle_errors(conn, %{reason: %Phoenix.ActionClauseError{}}), do: nil
+      end
 
       defp handle_errors(conn, %{reason: exception}) do
         error_report_builder = unquote(


### PR DESCRIPTION
`ActionClauseError` isn't really an unhandled error, but instead a result of a Bad Request that doesn't
provide params appropriate to satisfy the matched controller action. This exception will be rendered as an HTTP 400, and isn't logged as an error by Phoenix. This isn't really something that should show up in Bugsnag, and this sort of match error also results in the full `Plug.Conn` struct being sent to Bugsnag unsanitized, which is a security problem (`conn` can include the `secret_key_base`, used for session/token signing).