### PR TITLE
Prefer Map.from_struct over Map.delete(:__struct__)

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -28,7 +28,7 @@ defmodule Plugsnag do
         options =
           %Plugsnag.ErrorReport{}
           |> error_report_builder.build_error_report(conn)
-          |> Map.delete(:__struct__)
+          |> Map.from_struct
           |> Keyword.new
 
         apply(reporter(), :report, [exception | [options]])


### PR DESCRIPTION
Casting a struct into a map through the standard library is often safer and more future-proof.