### PR TITLE
Capture request id in error report

### DIFF
--- a/lib/plugsnag/basic_error_report_builder.ex
+++ b/lib/plugsnag/basic_error_report_builder.ex
@@ -23,7 +23,8 @@ defmodule Plugsnag.BasicErrorReportBuilder do
         query_string: conn.query_string,
         params: filter(:params, conn.params),
         headers: collect_req_headers(conn),
-        client_ip: format_ip(conn.remote_ip)
+        client_ip: format_ip(conn.remote_ip),
+        request_id: get_request_id(conn),
       }
     }
   end
@@ -65,5 +66,11 @@ defmodule Plugsnag.BasicErrorReportBuilder do
     ip
     |> Tuple.to_list
     |> Enum.join(".")
+  end
+
+  defp get_request_id(conn) do
+    conn
+    |> Plug.Conn.get_resp_header("x-request-id")
+    |> List.first
   end
 end

--- a/test/plugsnag/basic_error_report_builder_test.exs
+++ b/test/plugsnag/basic_error_report_builder_test.exs
@@ -12,6 +12,7 @@ defmodule Plugsnag.BasicErrorReportBuilderTest do
       conn
       |> put_req_header("accept", "application/json")
       |> put_req_header("x-user-id", "abc123")
+      |> put_resp_header("x-request-id", "42")
 
     error_report = BasicErrorReportBuilder.build_error_report(
       %ErrorReport{}, conn
@@ -25,6 +26,7 @@ defmodule Plugsnag.BasicErrorReportBuilderTest do
           method: "GET",
           port: 80,
           scheme: :http,
+          request_id: "42",
           query_string: "hello=computer",
           params: %{"hello" => "computer"},
           headers: %{


### PR DESCRIPTION
Capture request id as set by `Plug.RequestId`, if available.

Note: the header value is returned as an array, but even within the
Plug.RequestId code, the first item is assumed to be the value; hence
the call to `List.first/1`.

See https://github.com/elixir-plug/plug/blob/3d48af2b97d58c183a7b8390abc42ac5367b0770/lib/plug/request_id.ex#L49