### PR TITLE
Support for list of fields to redact as a string in the config file

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -32,7 +32,7 @@ defmodule Plugsnag do
       end
 
       defp redact(params) do
-        fields = redact_config[:fields] || ~w(password)
+        fields = String.split(redact_config[:fields]) || ~w(password)
         filtered = fields
                     |> Enum.filter(&Map.has_key?(params, &1))
                     |> Enum.flat_map(&redact_field(&1))

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -17,7 +17,7 @@ defmodule Plugsnag do
             stacktrace = System.stacktrace
 
             exception
-            |> Bugsnag.report(release_stage: Atom.to_string(Mix.env))
+            |> Bugsnag.report(release_stage: System.get_env("DEPLOYMENT_ENV") || System.get_env("MIX_ENV"))
 
             reraise exception, stacktrace
         end

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -32,7 +32,8 @@ defmodule Plugsnag do
       end
 
       defp redact(params) do
-        filtered = redact_config.fields
+        fields = redact_config[:fields] || ~w(password)
+        filtered = fields
                     |> Enum.filter(&Map.has_key?(params, &1))
                     |> Enum.flat_map(&redact_field(&1))
                     |> Enum.into(%{})
@@ -41,15 +42,14 @@ defmodule Plugsnag do
       end
 
       defp redact_field(field) do
-        %{field => redact_config.string}
+        %{field => redact_config[:string] || ~s([REDACTED])}
       end
 
       defp redact_config do
-        defaults = %{fields: ~w(password), string: ~s([REDACTED])}
-
         __MODULE__
         |> Application.get_application
-        |> Application.get_env(:redact_config, defaults)
+        |> Application.get_env(:redact_config)
+        |> Enum.into(%{})
       end
     end
   end

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -15,7 +15,7 @@ defmodule Plugsnag do
         rescue
           exception ->
             metadata = %{"conn" => %{
-              "query_params" => Map.get(conn, :params),
+              "query_params" => Map.get(conn, :params) |> redact,
               "assigns"      => Map.get(conn, :assigns),
               "path_info"    => Map.get(conn, :path_info),
               "method"       => Map.get(conn, :method),
@@ -29,6 +29,18 @@ defmodule Plugsnag do
 
             reraise exception, System.stacktrace
         end
+      end
+
+      defp redact(params) do
+        put_in(params, redact_config.fields, redact_config.string)
+      end
+
+      defp redact_config do
+        defaults = %{fields: ~w(password), string: ~s([REDACTED])}
+
+        __MODULE__
+        |> Application.get_application
+        |> Application.get_env(:redact_config, defaults)
       end
     end
   end

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -32,7 +32,16 @@ defmodule Plugsnag do
       end
 
       defp redact(params) do
-        put_in(params, redact_config.fields, redact_config.string)
+        filtered = redact_config.fields
+                    |> Enum.filter(&Map.has_key?(params, &1))
+                    |> Enum.flat_map(&redact_field(&1))
+                    |> Enum.into(%{})
+
+        Map.merge(params, filtered)
+      end
+
+      defp redact_field(field) do
+        %{field => redact_config.string}
       end
 
       defp redact_config do

--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -14,12 +14,20 @@ defmodule Plugsnag do
           super(conn, opts)
         rescue
           exception ->
-            stacktrace = System.stacktrace
+            metadata = %{"conn" => %{
+              "query_params" => Map.get(conn, :params),
+              "assigns"      => Map.get(conn, :assigns),
+              "path_info"    => Map.get(conn, :path_info),
+              "method"       => Map.get(conn, :method),
+            }}
+            release_stage = System.get_env("DEPLOYMENT_ENV") || System.get_env("MIX_ENV")
 
-            exception
-            |> Bugsnag.report(release_stage: System.get_env("DEPLOYMENT_ENV") || System.get_env("MIX_ENV"))
+            Bugsnag.report(exception, [
+              release_stage: release_stage,
+              metadata: metadata,
+            ])
 
-            reraise exception, stacktrace
+            reraise exception, System.stacktrace
         end
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Plugsnag.Mixfile do
 
   def project do
     [app: :plugsnag,
-     version: "1.0.1",
+     version: "1.2.0",
      elixir: "~> 1.0",
      package: package,
      description: """


### PR DESCRIPTION
This is necessary to work with Distillery and `REPLACE_OS_VARS=true` setting.