### PR TITLE
Include response headers in error report

### DIFF
--- a/lib/plugsnag/basic_error_report_builder.ex
+++ b/lib/plugsnag/basic_error_report_builder.ex
@@ -22,15 +22,16 @@ defmodule Plugsnag.BasicErrorReportBuilder do
         scheme: conn.scheme,
         query_string: conn.query_string,
         params: filter(:params, conn.params),
-        headers: collect_req_headers(conn),
+        req_headers: collect_headers(conn, :req),
+        resp_headers: collect_headers(conn, :resp),
         client_ip: format_ip(conn.remote_ip)
       }
     }
   end
 
-  defp collect_req_headers(conn) do
-    headers = Enum.reduce(conn.req_headers, %{}, fn({header, _}, acc) ->
-      Map.put(acc, header, Plug.Conn.get_req_header(conn, header) |> List.first)
+  defp collect_headers(conn, type) do
+    headers = Enum.reduce(Map.get(conn, :"#{type}_headers"), %{}, fn({header, _}, acc) ->
+      Map.put(acc, header, apply(Plug.Conn, :"get_#{type}_header", [conn, header]) |> List.first)
     end)
     filter(:headers, headers)
   end

--- a/test/plugsnag/basic_error_report_builder_test.exs
+++ b/test/plugsnag/basic_error_report_builder_test.exs
@@ -12,6 +12,7 @@ defmodule Plugsnag.BasicErrorReportBuilderTest do
       conn
       |> put_req_header("accept", "application/json")
       |> put_req_header("x-user-id", "abc123")
+      |> put_resp_header("x-request-id", "def456")
 
     error_report = BasicErrorReportBuilder.build_error_report(
       %ErrorReport{}, conn
@@ -27,9 +28,13 @@ defmodule Plugsnag.BasicErrorReportBuilderTest do
           scheme: :http,
           query_string: "hello=computer",
           params: %{"hello" => "computer"},
-          headers: %{
+          req_headers: %{
             "accept" => "application/json",
             "x-user-id" => "abc123"
+          },
+          resp_headers: %{
+            "x-request-id" => "def456",
+            "cache-control" => "max-age=0, private, must-revalidate"
           },
           client_ip: "127.0.0.1"
         }
@@ -63,7 +68,7 @@ defmodule Plugsnag.BasicErrorReportBuilderTest do
     assert %ErrorReport{
       metadata: %{
         request: %{
-          headers: %{"authorization" => "[FILTERED]"}
+          req_headers: %{"authorization" => "[FILTERED]"}
         }
       }
     } = error_report


### PR DESCRIPTION
I'm using Plug's built-in Plug.RequestId, which adds `x-request-id` to the response headers. Plugsnag was only including the request headers with the error metadata though. Including the response headers too makes it much easier to see the request ID and jump to our log files to find more detail on the request that triggered the error.

(I also renamed `:headers` to`:req_headers` to make it clearer, but I can change that back if desired.)