### PR TITLE
add full url to request metadata in basic error report

### DIFF
--- a/lib/plugsnag/basic_error_report_builder.ex
+++ b/lib/plugsnag/basic_error_report_builder.ex
@@ -18,6 +18,7 @@ defmodule Plugsnag.BasicErrorReportBuilder do
       request: %{
         request_path: conn.request_path,
         method: conn.method,
+        url: get_full_url(conn),
         port: conn.port,
         scheme: conn.scheme,
         query_string: conn.query_string,
@@ -33,6 +34,14 @@ defmodule Plugsnag.BasicErrorReportBuilder do
       Map.put(acc, header, Plug.Conn.get_req_header(conn, header) |> List.first)
     end)
     filter(:headers, headers)
+  end
+
+  defp get_full_url(conn) do
+    base = "#{conn.scheme}://#{conn.host}#{conn.request_path}"
+    case conn.query_string do
+      "" -> base
+      qs -> "#{base}?#{qs}"
+    end
   end
 
   defp filters_for(:headers) do

--- a/test/plugsnag/basic_error_report_builder_test.exs
+++ b/test/plugsnag/basic_error_report_builder_test.exs
@@ -23,6 +23,7 @@ defmodule Plugsnag.BasicErrorReportBuilderTest do
         request: %{
           request_path: "/",
           method: "GET",
+          url: "http://#{conn.host}/?hello=computer",
           port: 80,
           scheme: :http,
           query_string: "hello=computer",


### PR DESCRIPTION
Bugsnag offers a handy "copy curl command to clipboard" option in the request tab of their error reports.  This makes errors very easy to reproduce locally and then fix.  

<img width="495" alt="screen shot 2018-05-02 at 10 19 40 pm" src="https://user-images.githubusercontent.com/2029383/39557637-eff2cbcc-4e56-11e8-9bf0-ced0360baa22.png">

However, this option does not appear if the error metadata does not contain a "url" field.  This PR adds this field to the request metadata in the basic error report which should make this copy curl feature available to all Plugsnag users by default.  