### PR TITLE
Relax requirements for Bugsnag to allow 2.x versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Plugsnag.Mixfile do
   end
 
   defp deps do
-    [{:bugsnag, "~> 1.3"},
+    [{:bugsnag, "~> 1.3 or ~> 2.0"},
      {:plug, "~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev},
      {:dialyxir, "~> 0.3.5", only: [:dev]}


### PR DESCRIPTION
jarednorman/bugsnag-elixir#86 is potentially breaking for clients, so it required a major version increment, but it should be compatible with plugsnag.