### PR TITLE
Fix stacktraces in Erlang/OTP 23

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -22,7 +22,7 @@ defmodule Plugsnag do
     report_error(conn, assigns, opts)
   end
 
-  defp report_error(conn, %{reason: exception}, opts) do
+  defp report_error(conn, %{reason: exception, stack: stack}, opts) do
     error_report_builder =
       Keyword.get(opts, :error_report_builder, Plugsnag.BasicErrorReportBuilder)
 
@@ -31,6 +31,7 @@ defmodule Plugsnag do
       |> error_report_builder.build_error_report(conn)
       |> Map.from_struct()
       |> Keyword.new()
+      |> Keyword.put(:stacktrace, stack)
 
     reporter = Application.get_env(:plugsnag, :reporter, Bugsnag)
     apply(reporter, :report, [exception | [options]])


### PR DESCRIPTION
### Issue

When using Erlang/OTP 23, Plugsnag is not reporting a stack trace

### Cause


In Erlang/OTP 23, `System.stacktrace()` always returns an empty list:

https://github.com/elixir-lang/elixir/blob/v1.11.3/lib/elixir/lib/system.ex#L594

This prevents Bugsnag from inferring the stack trace when reporting a crash:

https://github.com/bugsnag-elixir/bugsnag-elixir/blob/ffdb44663cdd69401ecca2b4f856df761443fbab/lib/bugsnag/reporter.ex#L89

### Fix

Plugsnag needs to pass along the stacktrace (provided by Plug).  This PR does that.