### PR TITLE
Fix CHANGELOG PR reference in v1.6.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.6.1
 
 ### Fixed
-- pass along stacktrace from Plug.ErrorHandler to Bugsnag [#44](https://github.com/bugsnag-elixir/bugsnag-elixir/pull/44)
+- pass along stacktrace from Plug.ErrorHandler to Bugsnag [#44](https://github.com/bugsnag-elixir/plugsnag/pull/44)
 
 ## v1.6.0
 


### PR DESCRIPTION
I was a big confused when I clicked the link to the PR and saw code that seemed entirely un-related to the change described. Turns out the URL was accidentally linking cross-project 😃 