### PR TITLE
Publish `handle_errors` to avoid dialyzer error under erlang 25.1

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -3,7 +3,7 @@ defmodule Plugsnag do
     quote location: :keep do
       use Plug.ErrorHandler
 
-      defp handle_errors(conn, assigns) do
+      def handle_errors(conn, assigns) do
         Plugsnag.handle_errors(conn, assigns, unquote(options))
       end
     end


### PR DESCRIPTION
`mix dialyzer` started to emit the following error on this line:

    Callback function handle_errors/2 exists but is not exported (behaviour 'Elixir.Plug.ErrorHandler')