### PR TITLE
Exclude `priv` directory from output package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule Plugsnag.Mixfile do
       contributors: ["Jared Norman", "Andrew Harvey", "Guilherme de Maio"],
       maintainers: ["Andrew Harvey", "Guilherme de Maio"],
       licenses: ["MIT"],
+      files: ~w(lib .formatter.exs mix.exs README.md LICENSE.md CHANGELOG.md),
       links: %{
         Changelog: "https://hexdocs.pm/plugsnag/changelog.html",
         GitHub: @source_url


### PR DESCRIPTION
TLDR: It contains dialyzer/dialyxir plt files which are rather hefty (5MB).

I stumbled upon it today looking at trimming `mix release` file size. To my surprise plugsnag was the main offender there with a hefty 5MB+ size, entirely due to `priv/plts` folder with plt files being included in the package.

```bash
[nix-shell:~/Development/Web/template]$ mix hex.package fetch plugsnag
plugsnag v1.7.1 downloaded to /home/jakub/Development/Web/template/plugsnag-1.7.1.tar

[nix-shell:~/Development/Web/template]$ stat plugsnag-1.7.1.tar
  File: /home/jakub/Development/Web/template/plugsnag-1.7.1.tar
  Size: 5386240   	Blocks: 10520      IO Block: 4096   regular file
Device: 259,1	Inode: 2892405     Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/   jakub)   Gid: (  100/   users)
Access: 2025-06-04 16:47:13.101554595 +0200
Modify: 2025-06-04 16:47:13.094554708 +0200
Change: 2025-06-04 16:47:13.094554708 +0200
 Birth: 2025-06-04 16:47:13.094554708 +0200

[nix-shell:~/Development/Web/template]$ tar fx plugsnag-1.7.1.tar

[nix-shell:~/Development/Web/template]$ tar fx contents.tar.gz

[nix-shell:~/Development/Web/template]$ l priv/plts/
total 5.3M
drwxr-xr-x 2 jakub users 4.0K Jun  4 16:55 .
drwxr-xr-x 4 jakub users 4.0K Jun  4 16:55 ..
-rw-r--r-- 1 jakub users 1.7M Jan  1  2000 dialyxir_erlang-25.1.1_elixir-1.14.1.plt
-rw-r--r-- 1 jakub users 1.3M Jan  1  2000 dialyxir_erlang-25.1.1.plt
-rw-r--r-- 1 jakub users 2.3M Jan  1  2000 dialyzer.plt
-rw-r--r-- 1 jakub users   20 Jan  1  2000 dialyzer.plt.hash
```

Please correct me if I'm wrong but we don't need `priv/plts` to be included in the package, or do we?
If there's a better way to achieve the same result, then please feel free to use it instead of this PR.